### PR TITLE
Update domain for the lokalise API

### DIFF
--- a/lib/fastlane/plugin/lokalise/actions/add_keys_to_lokalise_action.rb
+++ b/lib/fastlane/plugin/lokalise/actions/add_keys_to_lokalise_action.rb
@@ -27,7 +27,7 @@ module Fastlane
           data: keysObjects.to_json
         }
 
-        uri = URI("https://api.lokalise.co/api/string/set")
+        uri = URI("https://api.lokalise.com/api/string/set")
         request = Net::HTTP::Post.new(uri)
         request.set_form_data(request_data)
 

--- a/lib/fastlane/plugin/lokalise/actions/lokalise_action.rb
+++ b/lib/fastlane/plugin/lokalise/actions/lokalise_action.rb
@@ -40,7 +40,7 @@ module Fastlane
           request_data["include_tags"] = tags
         end
 
-        uri = URI("https://api.lokalise.co/api2/projects/#{project_identifier}/files/download")
+        uri = URI("https://api.lokalise.com/api2/projects/#{project_identifier}/files/download")
         request = Net::HTTP::Post.new(uri, {'content-type' => 'application/json', 'x-api-token' => "#{token}"})
         request.body = request_data.to_json
 

--- a/lib/fastlane/plugin/lokalise/actions/lokalise_metadata_action.rb
+++ b/lib/fastlane/plugin/lokalise/actions/lokalise_metadata_action.rb
@@ -142,7 +142,7 @@ module Fastlane
           id: @params[:project_identifier]
         }.merge(data)
 
-        uri = URI("https://api.lokalise.co/api/#{path}")
+        uri = URI("https://api.lokalise.com/api/#{path}")
         request = Net::HTTP::Post.new(uri)
         request.set_form_data(request_data)
   
@@ -438,7 +438,7 @@ module Fastlane
 
 
       def self.details
-        "This action scans fastlane/metadata folder and uploads metadata to lokalise.co"
+        "This action scans fastlane/metadata folder and uploads metadata to lokalise.com"
       end
 
 


### PR DESCRIPTION
The domain .co has been shutdown. We must now do requests to the .com domain.
