### PR TITLE
[MOB] Fix adding 2 strings into the same line

### DIFF
--- a/lib/fastlane/plugin/lokalise/actions/lokalise_action.rb
+++ b/lib/fastlane/plugin/lokalise/actions/lokalise_action.rb
@@ -120,6 +120,7 @@ module Fastlane
 
           destFile = File.open(path, "r")
           destFile.each_line do |oldLine|
+            oldLine.chomp!
             oldKeyValue = oldLine.split('" = "')
             translations[oldKeyValue[0]] = oldKeyValue[1]
           end
@@ -127,6 +128,7 @@ module Fastlane
 
           tempFile = File.open(tempFilePath, "r")
           tempFile.each_line do |newLine|
+            newLine.chomp!
             newKeyValue = newLine.split('" = "')
             translations[newKeyValue[0]] = newKeyValue[1]
           end
@@ -149,6 +151,7 @@ module Fastlane
 
           destFile = File.open(path, "r")
           destFile.each_line do |oldLine|
+            oldLine.chomp!
             oldKeyValue = oldLine.split('" = "')
             translations[oldKeyValue[0]] = oldKeyValue[1]
           end
@@ -156,6 +159,7 @@ module Fastlane
 
           tempFile = File.open(tempFilePath, "r")
           tempFile.each_line do |newLine|
+            newLine.chomp!
             newKeyValue = newLine.split('" = "')
             translations[newKeyValue[0]] = newKeyValue[1] unless translations[newKeyValue[0]].nil?
           end
@@ -171,14 +175,15 @@ module Fastlane
         FileUtils.rm(path) if File.file? path
 
         sortedTranslations = Hash[ translations.sort_by { |key, val| key.downcase } ]
-        
+        translationsArray = Array.new()
         File.open(path, "w+") do |file|
           sortedTranslations.each { |key, value|
             leftSide = key
             rightSide = value
             line = "#{leftSide}\" = \"#{rightSide}"
-            file.write(line)
+            translationsArray.push(line)
           }
+          file.write(translationsArray.join("\n"))
         end
       end
 

--- a/lib/fastlane/plugin/lokalise/actions/lokalise_action.rb
+++ b/lib/fastlane/plugin/lokalise/actions/lokalise_action.rb
@@ -62,7 +62,7 @@ module Fastlane
           response = http.request(zipRequest)
           if response.content_type == "application/zip" or response.content_type == "application/octet-stream" then
             FileUtils.mkdir_p("lokalisetmp")
-            open("lokalisetmp/a.zip", "wb") { |file| 
+            open("lokalisetmp/a.zip", "wb") { |file|
               file.write(response.body)
             }
             unzip_file("lokalisetmp/a.zip", destination, clean_destination, file_strategy)
@@ -96,81 +96,80 @@ module Fastlane
                override_file(zip_file, f, f_path)
              elsif file_strategy == "merge" then
                merge_file(zip_file, f, f_path)
-             else 
+             else
                update_file(zip_file, f, f_path)
              end
            }
         }
       end
-        
+
       def self.override_file(zip_file, file, path)
         FileUtils.rm(path) if File.file? path
         zip_file.extract(file, path)
       end
-          
+
       def self.merge_file(zip_file, file, path)
         if File.file? path then
           tempFilePath = "lokalisetmp/" + file.name
-          
+
           FileUtils.rm(tempFilePath) if File.file? tempFilePath
           FileUtils.mkdir_p(File.dirname(tempFilePath))
           zip_file.extract(file, tempFilePath)
-          
+
           translations = Hash.new
-          
+
           destFile = File.open(path, "r")
           destFile.each_line do |oldLine|
             oldKeyValue = oldLine.split('" = "')
             translations[oldKeyValue[0]] = oldKeyValue[1]
           end
           destFile.close
-          
+
           tempFile = File.open(tempFilePath, "r")
           tempFile.each_line do |newLine|
             newKeyValue = newLine.split('" = "')
             translations[newKeyValue[0]] = newKeyValue[1]
           end
           tempFile.close
-          
+
           write_file(translations, path)
           else
           zip_file.extract(file, path)
         end
       end
-      
+
       def self.update_file(zip_file, file, path)
         if File.file? path then
           tempFilePath = "lokalisetmp/" + file.name
-          
           FileUtils.rm(tempFilePath) if File.file? tempFilePath
           FileUtils.mkdir_p(File.dirname(tempFilePath))
           zip_file.extract(file, tempFilePath)
-          
+
           translations = Hash.new
-          
+
           destFile = File.open(path, "r")
           destFile.each_line do |oldLine|
             oldKeyValue = oldLine.split('" = "')
             translations[oldKeyValue[0]] = oldKeyValue[1]
           end
           destFile.close
-          
+
           tempFile = File.open(tempFilePath, "r")
           tempFile.each_line do |newLine|
             newKeyValue = newLine.split('" = "')
             translations[newKeyValue[0]] = newKeyValue[1] unless translations[newKeyValue[0]].nil?
           end
           tempFile.close
-          
+
           write_file(translations, path)
           else
           zip_file.extract(file, path)
         end
       end
-        
+
       def self.write_file(translations, path)
         FileUtils.rm(path) if File.file? path
-        
+
         sortedTranslations = Hash[ translations.sort_by { |key, val| key.downcase } ]
         
         File.open(path, "w+") do |file|
@@ -294,7 +293,7 @@ module Fastlane
 
 
       def self.is_supported?(platform)
-        [:ios, :android, :mac].include? platform 
+        [:ios, :android, :mac].include? platform
       end
 
 


### PR DESCRIPTION
This PR fixes the issue in which we end up with 2 translated strings in the same line of the .strings file.

The root cause is that we are using each_line to read from the file, which gets the new line character at the end. When the line is the last, we don't get a new line at the end. When we insert this line in the middle of the hash and then write it to a file, it misses the \n at the end.

This is fixed by always removing the `\n` at the end of the line using chomp, and then adding a `\n` when writing to file.

I also took the chance to fix the file indentation (empty spaces in lines or spaces before a line end)